### PR TITLE
Mistaken paths

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -6,9 +6,9 @@
 extends: default
 
 ignore: |
-  collections/*
+  collections/
   !collections/requirements.yml
-  roles/*
+  roles/
   !roles/requirements.yml
   
 rules:


### PR DESCRIPTION
Made a mistake in the syntax for the paths: https://yamllint.readthedocs.io/en/stable/configuration.html#ignoring-paths