### PR TITLE
Removed vault config

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -18,8 +18,3 @@ roles_path = ./roles
 
 # Installs collections into [current dir]/collections/ansible_collections/namespace/collection
 collections_paths = ./collections
-
-[lookup_hashi_vault]
-# Default to Approle authentication to simplify Vault lookups
-auth_method=approle
-


### PR DESCRIPTION
No need to enforce approle auth for vault lookups, since that is provided by env var in AWX, and I keep commenting it out to use tokens locally